### PR TITLE
feat: add SecretValue.metadata() for non-sensitive fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ dbCreds.VersionId // => "${uuid}"
 dbCreds.VersionStages // => ["AWSCURRENT"]
 dbCreds.CreatedDate // => Date
 
+dbCreds.metadata() // => { ARN, Name, VersionId, VersionStages, CreatedDate }
+
 // "string" if the secret was stored as a string, "binary" if the secret was stored as a binary
 dbCreds.payloadType // => "string"
 

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -1,6 +1,6 @@
-import { GetSecretValueRequest } from "@aws-sdk/client-secrets-manager";
+import type { GetSecretValueRequest } from "@aws-sdk/client-secrets-manager";
 import { SecretValue } from "./secret-value.ts";
-import { SecretsManager } from "./types.ts";
+import type { SecretsManager } from "./types.ts";
 
 export type FetchOptions = Omit<GetSecretValueRequest, "SecretId">;
 

--- a/src/secret-value.test.ts
+++ b/src/secret-value.test.ts
@@ -235,6 +235,20 @@ describe("SecretValue", () => {
     });
   });
 
+  describe("metadata()", () => {
+    it("with a string secret returns the expected metadata fields", () => {
+      const { SecretString, $metadata, ...expected } = stringSecretRes;
+
+      assert.deepEqual(expected, stringSecret.metadata());
+    });
+
+    it("with a binary secret returns the expected metadata fields", () => {
+      const { SecretBinary, $metadata, ...expected } = stringBinaryRes;
+
+      assert.deepEqual(expected, stringBinarySecret.metadata());
+    });
+  });
+
   describe("bytes()", () => {
     it("returns the expected Buffer", async () => {
       const res = await stringBinarySecret.bytes();

--- a/src/secret-value.ts
+++ b/src/secret-value.ts
@@ -1,10 +1,10 @@
-import { GetSecretValueResponse } from "@aws-sdk/client-secrets-manager";
+import type { GetSecretValueResponse } from "@aws-sdk/client-secrets-manager";
 import {
   InvalidSecretError,
   SecretParseError,
   UnsupportedOperationError,
 } from "./errors.ts";
-import { SecretPayloadType } from "./types.ts";
+import type { GetSecretValueMetadata, SecretPayloadType } from "./types.ts";
 import { getSecretContent, SecretContent } from "./utils/secret-content.ts";
 import { deepCopySecretValueCommandOutput } from "./utils/secret-copier.ts";
 
@@ -102,6 +102,29 @@ export class SecretValue {
     }
 
     return this.#content.type;
+  }
+
+  /**
+   * Returns non-sensitive metadata about the secret
+   *
+   * Current fields:
+   *
+   * - ARN
+   * - Name
+   * - VersionId
+   * - VersionStages
+   * - CreatedDate
+   */
+  metadata(): GetSecretValueMetadata {
+    const { ARN, CreatedDate, Name, VersionId, VersionStages } = this.#input;
+
+    return deepCopySecretValueCommandOutput({
+      ARN,
+      Name,
+      VersionId,
+      VersionStages,
+      CreatedDate,
+    });
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,12 @@
-import { SecretsManager as AWSSecretsManager } from "@aws-sdk/client-secrets-manager";
+import type {
+  SecretsManager as AWSSecretsManager,
+  GetSecretValueResponse,
+} from "@aws-sdk/client-secrets-manager";
+
+export type GetSecretValueMetadata = Omit<
+  GetSecretValueResponse,
+  "SecretString" | "SecretBinary"
+>;
 
 export type SecretsManager = Pick<AWSSecretsManager, "getSecretValue">;
 

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1,4 +1,5 @@
-import { GetSecretValueResponse } from "@aws-sdk/client-secrets-manager";
+import { GetSecretValueCommandOutput } from "@aws-sdk/client-secrets-manager";
+import { randomUUID } from "node:crypto";
 
 export const EXAMPLE_JSON = {
   str: "hello world",
@@ -20,23 +21,31 @@ export const EXAMPLE_STRING_BUFFER = Buffer.from(EXAMPLE_STRING);
 export const toGetSecretResponse = (
   name: string,
   content: string,
-): GetSecretValueResponse => ({
+): GetSecretValueCommandOutput => ({
   ARN: `arn:aws:secretsmanager:us-east-1:01234567890:secret:${name}-1a2b3c`,
   Name: name,
   VersionId: "1a2b3c",
   SecretString: content,
   VersionStages: ["AWSCURRENT"],
   CreatedDate: new Date("2022-01-23T12:34:56.000Z"),
+  $metadata: {
+    httpStatusCode: 200,
+    requestId: randomUUID(),
+  },
 });
 
 export const toGetBinarySecretResponse = (
   name: string,
   content: Buffer,
-): GetSecretValueResponse => ({
+): GetSecretValueCommandOutput => ({
   ARN: `arn:aws:secretsmanager:us-east-1:01234567890:secret:${name}-1a2b3c`,
   Name: name,
   VersionId: "1a2b3c",
   SecretBinary: content,
   VersionStages: ["AWSCURRENT"],
   CreatedDate: new Date("2022-01-23T12:34:56.000Z"),
+  $metadata: {
+    httpStatusCode: 200,
+    requestId: randomUUID(),
+  },
 });


### PR DESCRIPTION
This PR adds a new `metadata()` method that returns the non-`Secret*` fields in cases where the non-sensitive fields need to be fetched in bulk. The method is using an explicit opt-in method instead of an omit, but could be changed in the future if need be.

* refactor: use `import type` when only importing types